### PR TITLE
Add teacher admin mode with authentication

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -5,10 +5,14 @@ A super simple FastAPI application that allows students to view and sign up
 for extracurricular activities at Mergington High School.
 """
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Depends
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
+from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 import os
+import json
+import hashlib
+import secrets
 from pathlib import Path
 
 app = FastAPI(title="Mergington High School API",
@@ -77,6 +81,49 @@ activities = {
     }
 }
 
+# In-memory session store: token -> username
+active_sessions: dict[str, str] = {}
+
+TEACHERS_FILE = current_dir / "teachers.json"
+security = HTTPBearer(auto_error=False)
+
+
+def _load_teachers() -> dict:
+    if not TEACHERS_FILE.exists():
+        return {}
+    with open(TEACHERS_FILE, "r") as f:
+        return json.load(f)
+
+
+def _save_teachers(teachers: dict) -> None:
+    with open(TEACHERS_FILE, "w") as f:
+        json.dump(teachers, f, indent=2)
+
+
+def _hash_password(password: str) -> str:
+    """Hash a password with a random salt using PBKDF2-HMAC-SHA256."""
+    salt = secrets.token_hex(16)
+    hashed = hashlib.pbkdf2_hmac("sha256", password.encode(), salt.encode(), 100000).hex()
+    return f"pbkdf2:{salt}:{hashed}"
+
+
+def _verify_password(password: str, stored: str) -> bool:
+    """Verify a password against a stored hash (or plain: prefix for initial setup)."""
+    if stored.startswith("plain:"):
+        return password == stored[len("plain:"):]
+    if stored.startswith("pbkdf2:"):
+        _, salt, hashed = stored.split(":", 2)
+        check = hashlib.pbkdf2_hmac("sha256", password.encode(), salt.encode(), 100000).hex()
+        return secrets.compare_digest(check, hashed)
+    return False
+
+
+def get_current_teacher(credentials: HTTPAuthorizationCredentials = Depends(security)) -> str:
+    """Validate bearer token and return the teacher's username."""
+    if credentials is None or credentials.credentials not in active_sessions:
+        raise HTTPException(status_code=401, detail="Not authenticated as a teacher")
+    return active_sessions[credentials.credentials]
+
 
 @app.get("/")
 def root():
@@ -88,9 +135,36 @@ def get_activities():
     return activities
 
 
+@app.post("/auth/login")
+def login(username: str, password: str):
+    """Authenticate a teacher and return a session token."""
+    teachers = _load_teachers()
+    stored = teachers.get(username)
+    if stored is None or not _verify_password(password, stored):
+        raise HTTPException(status_code=401, detail="Invalid username or password")
+
+    # Upgrade plain-text password to hashed on first successful login
+    if stored.startswith("plain:"):
+        teachers[username] = _hash_password(password)
+        _save_teachers(teachers)
+
+    token = secrets.token_hex(32)
+    active_sessions[token] = username
+    return {"token": token, "username": username}
+
+
+@app.post("/auth/logout")
+def logout(teacher: str = Depends(get_current_teacher),
+           credentials: HTTPAuthorizationCredentials = Depends(security)):
+    """Invalidate the current session token."""
+    active_sessions.pop(credentials.credentials, None)
+    return {"message": "Logged out successfully"}
+
+
 @app.post("/activities/{activity_name}/signup")
-def signup_for_activity(activity_name: str, email: str):
-    """Sign up a student for an activity"""
+def signup_for_activity(activity_name: str, email: str,
+                        teacher: str = Depends(get_current_teacher)):
+    """Sign up a student for an activity (teachers only)."""
     # Validate activity exists
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")
@@ -105,14 +179,22 @@ def signup_for_activity(activity_name: str, email: str):
             detail="Student is already signed up"
         )
 
+    # Validate max participants not exceeded
+    if len(activity["participants"]) >= activity["max_participants"]:
+        raise HTTPException(
+            status_code=400,
+            detail="Activity is full"
+        )
+
     # Add student
     activity["participants"].append(email)
     return {"message": f"Signed up {email} for {activity_name}"}
 
 
 @app.delete("/activities/{activity_name}/unregister")
-def unregister_from_activity(activity_name: str, email: str):
-    """Unregister a student from an activity"""
+def unregister_from_activity(activity_name: str, email: str,
+                              teacher: str = Depends(get_current_teacher)):
+    """Unregister a student from an activity (teachers only)."""
     # Validate activity exists
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -2,39 +2,127 @@ document.addEventListener("DOMContentLoaded", () => {
   const activitiesList = document.getElementById("activities-list");
   const activitySelect = document.getElementById("activity");
   const signupForm = document.getElementById("signup-form");
+  const signupContainer = document.getElementById("signup-container");
   const messageDiv = document.getElementById("message");
 
-  // Function to fetch activities from API
+  // Auth elements
+  const loginBtn = document.getElementById("login-btn");
+  const logoutBtn = document.getElementById("logout-btn");
+  const teacherGreeting = document.getElementById("teacher-greeting");
+  const loginModal = document.getElementById("login-modal");
+  const loginForm = document.getElementById("login-form");
+  const cancelLoginBtn = document.getElementById("cancel-login-btn");
+  const loginError = document.getElementById("login-error");
+
+  // Session state
+  let authToken = sessionStorage.getItem("authToken");
+  let teacherName = sessionStorage.getItem("teacherName");
+
+  // ── Auth UI helpers ────────────────────────────────────────────────────────
+
+  function updateAuthUI() {
+    if (authToken) {
+      loginBtn.classList.add("hidden");
+      logoutBtn.classList.remove("hidden");
+      teacherGreeting.textContent = `Welcome, ${teacherName}`;
+      teacherGreeting.classList.remove("hidden");
+      signupContainer.classList.remove("hidden");
+    } else {
+      loginBtn.classList.remove("hidden");
+      logoutBtn.classList.add("hidden");
+      teacherGreeting.classList.add("hidden");
+      signupContainer.classList.add("hidden");
+    }
+    // Re-render to show/hide delete buttons
+    fetchActivities();
+  }
+
+  loginBtn.addEventListener("click", () => {
+    loginModal.classList.remove("hidden");
+    loginError.classList.add("hidden");
+    loginForm.reset();
+  });
+
+  cancelLoginBtn.addEventListener("click", () => {
+    loginModal.classList.add("hidden");
+  });
+
+  loginModal.addEventListener("click", (e) => {
+    if (e.target === loginModal) loginModal.classList.add("hidden");
+  });
+
+  loginForm.addEventListener("submit", async (e) => {
+    e.preventDefault();
+    const username = document.getElementById("username").value;
+    const password = document.getElementById("password").value;
+
+    try {
+      const response = await fetch(
+        `/auth/login?username=${encodeURIComponent(username)}&password=${encodeURIComponent(password)}`,
+        { method: "POST" }
+      );
+      const result = await response.json();
+      if (response.ok) {
+        authToken = result.token;
+        teacherName = result.username;
+        sessionStorage.setItem("authToken", authToken);
+        sessionStorage.setItem("teacherName", teacherName);
+        loginModal.classList.add("hidden");
+        updateAuthUI();
+      } else {
+        loginError.textContent = result.detail || "Login failed";
+        loginError.classList.remove("hidden");
+      }
+    } catch {
+      loginError.textContent = "Could not connect. Please try again.";
+      loginError.classList.remove("hidden");
+    }
+  });
+
+  logoutBtn.addEventListener("click", async () => {
+    if (authToken) {
+      await fetch("/auth/logout", {
+        method: "POST",
+        headers: { Authorization: `Bearer ${authToken}` },
+      }).catch(() => {});
+    }
+    authToken = null;
+    teacherName = null;
+    sessionStorage.removeItem("authToken");
+    sessionStorage.removeItem("teacherName");
+    updateAuthUI();
+  });
+
+  // ── Activities ─────────────────────────────────────────────────────────────
+
   async function fetchActivities() {
     try {
       const response = await fetch("/activities");
       const activities = await response.json();
 
-      // Clear loading message
       activitiesList.innerHTML = "";
+      activitySelect.innerHTML = '<option value="">-- Select an activity --</option>';
 
-      // Populate activities list
       Object.entries(activities).forEach(([name, details]) => {
         const activityCard = document.createElement("div");
         activityCard.className = "activity-card";
 
-        const spotsLeft =
-          details.max_participants - details.participants.length;
+        const spotsLeft = details.max_participants - details.participants.length;
 
-        // Create participants HTML with delete icons instead of bullet points
         const participantsHTML =
           details.participants.length > 0
             ? `<div class="participants-section">
-              <h5>Participants:</h5>
-              <ul class="participants-list">
-                ${details.participants
-                  .map(
-                    (email) =>
-                      `<li><span class="participant-email">${email}</span><button class="delete-btn" data-activity="${name}" data-email="${email}">❌</button></li>`
-                  )
-                  .join("")}
-              </ul>
-            </div>`
+                <h5>Participants:</h5>
+                <ul class="participants-list">
+                  ${details.participants
+                    .map((email) =>
+                      authToken
+                        ? `<li><span class="participant-email">${email}</span><button class="delete-btn" data-activity="${name}" data-email="${email}">❌</button></li>`
+                        : `<li><span class="participant-email">${email}</span></li>`
+                    )
+                    .join("")}
+                </ul>
+              </div>`
             : `<p><em>No participants yet</em></p>`;
 
         activityCard.innerHTML = `
@@ -42,32 +130,28 @@ document.addEventListener("DOMContentLoaded", () => {
           <p>${details.description}</p>
           <p><strong>Schedule:</strong> ${details.schedule}</p>
           <p><strong>Availability:</strong> ${spotsLeft} spots left</p>
-          <div class="participants-container">
-            ${participantsHTML}
-          </div>
+          <div class="participants-container">${participantsHTML}</div>
         `;
 
         activitiesList.appendChild(activityCard);
 
-        // Add option to select dropdown
         const option = document.createElement("option");
         option.value = name;
         option.textContent = name;
         activitySelect.appendChild(option);
       });
 
-      // Add event listeners to delete buttons
-      document.querySelectorAll(".delete-btn").forEach((button) => {
-        button.addEventListener("click", handleUnregister);
-      });
+      if (authToken) {
+        document.querySelectorAll(".delete-btn").forEach((btn) =>
+          btn.addEventListener("click", handleUnregister)
+        );
+      }
     } catch (error) {
-      activitiesList.innerHTML =
-        "<p>Failed to load activities. Please try again later.</p>";
+      activitiesList.innerHTML = "<p>Failed to load activities. Please try again later.</p>";
       console.error("Error fetching activities:", error);
     }
   }
 
-  // Handle unregister functionality
   async function handleUnregister(event) {
     const button = event.target;
     const activity = button.getAttribute("data-activity");
@@ -75,86 +159,51 @@ document.addEventListener("DOMContentLoaded", () => {
 
     try {
       const response = await fetch(
-        `/activities/${encodeURIComponent(
-          activity
-        )}/unregister?email=${encodeURIComponent(email)}`,
+        `/activities/${encodeURIComponent(activity)}/unregister?email=${encodeURIComponent(email)}`,
         {
           method: "DELETE",
+          headers: { Authorization: `Bearer ${authToken}` },
         }
       );
-
       const result = await response.json();
-
-      if (response.ok) {
-        messageDiv.textContent = result.message;
-        messageDiv.className = "success";
-
-        // Refresh activities list to show updated participants
-        fetchActivities();
-      } else {
-        messageDiv.textContent = result.detail || "An error occurred";
-        messageDiv.className = "error";
-      }
-
-      messageDiv.classList.remove("hidden");
-
-      // Hide message after 5 seconds
-      setTimeout(() => {
-        messageDiv.classList.add("hidden");
-      }, 5000);
-    } catch (error) {
-      messageDiv.textContent = "Failed to unregister. Please try again.";
-      messageDiv.className = "error";
-      messageDiv.classList.remove("hidden");
-      console.error("Error unregistering:", error);
+      showMessage(response.ok ? result.message : result.detail || "An error occurred", response.ok);
+      if (response.ok) fetchActivities();
+    } catch {
+      showMessage("Failed to unregister. Please try again.", false);
     }
   }
 
-  // Handle form submission
   signupForm.addEventListener("submit", async (event) => {
     event.preventDefault();
-
     const email = document.getElementById("email").value;
     const activity = document.getElementById("activity").value;
 
     try {
       const response = await fetch(
-        `/activities/${encodeURIComponent(
-          activity
-        )}/signup?email=${encodeURIComponent(email)}`,
+        `/activities/${encodeURIComponent(activity)}/signup?email=${encodeURIComponent(email)}`,
         {
           method: "POST",
+          headers: { Authorization: `Bearer ${authToken}` },
         }
       );
-
       const result = await response.json();
-
+      showMessage(response.ok ? result.message : result.detail || "An error occurred", response.ok);
       if (response.ok) {
-        messageDiv.textContent = result.message;
-        messageDiv.className = "success";
         signupForm.reset();
-
-        // Refresh activities list to show updated participants
         fetchActivities();
-      } else {
-        messageDiv.textContent = result.detail || "An error occurred";
-        messageDiv.className = "error";
       }
-
-      messageDiv.classList.remove("hidden");
-
-      // Hide message after 5 seconds
-      setTimeout(() => {
-        messageDiv.classList.add("hidden");
-      }, 5000);
-    } catch (error) {
-      messageDiv.textContent = "Failed to sign up. Please try again.";
-      messageDiv.className = "error";
-      messageDiv.classList.remove("hidden");
-      console.error("Error signing up:", error);
+    } catch {
+      showMessage("Failed to sign up. Please try again.", false);
     }
   });
 
-  // Initialize app
-  fetchActivities();
+  function showMessage(text, success) {
+    messageDiv.textContent = text;
+    messageDiv.className = success ? "success" : "error";
+    messageDiv.classList.remove("hidden");
+    setTimeout(() => messageDiv.classList.add("hidden"), 5000);
+  }
+
+  // Initial load
+  updateAuthUI();
 });

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -10,7 +10,34 @@
     <header>
       <h1>Mergington High School</h1>
       <h2>Extracurricular Activities</h2>
+      <div id="auth-controls">
+        <span id="teacher-greeting" class="hidden"></span>
+        <button id="login-btn" class="auth-btn">👤 Teacher Login</button>
+        <button id="logout-btn" class="auth-btn hidden">Logout</button>
+      </div>
     </header>
+
+    <!-- Login Modal -->
+    <div id="login-modal" class="modal hidden">
+      <div class="modal-content">
+        <h3>Teacher Login</h3>
+        <form id="login-form">
+          <div class="form-group">
+            <label for="username">Username:</label>
+            <input type="text" id="username" required placeholder="e.g. ms.johnson" autocomplete="username" />
+          </div>
+          <div class="form-group">
+            <label for="password">Password:</label>
+            <input type="password" id="password" required placeholder="Password" autocomplete="current-password" />
+          </div>
+          <div id="login-error" class="error hidden"></div>
+          <div class="modal-actions">
+            <button type="submit">Login</button>
+            <button type="button" id="cancel-login-btn">Cancel</button>
+          </div>
+        </form>
+      </div>
+    </div>
 
     <main>
       <section id="activities-container">
@@ -21,8 +48,8 @@
         </div>
       </section>
 
-      <section id="signup-container">
-        <h3>Sign Up for an Activity</h3>
+      <section id="signup-container" class="hidden">
+        <h3>Sign Up a Student</h3>
         <form id="signup-form">
           <div class="form-group">
             <label for="email">Student Email:</label>

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -22,6 +22,7 @@ header {
   background-color: #1a237e;
   color: white;
   border-radius: 5px;
+  position: relative;
 }
 
 header h1 {
@@ -197,4 +198,76 @@ footer {
   margin-top: 30px;
   padding: 20px;
   color: #666;
+}
+
+/* ── Auth controls in header ──────────────────────────────────────────────── */
+
+#auth-controls {
+  position: absolute;
+  top: 50%;
+  right: 20px;
+  transform: translateY(-50%);
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.auth-btn {
+  background-color: rgba(255, 255, 255, 0.2);
+  color: white;
+  border: 1px solid rgba(255, 255, 255, 0.5);
+  padding: 6px 12px;
+  font-size: 14px;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.auth-btn:hover {
+  background-color: rgba(255, 255, 255, 0.35);
+}
+
+#teacher-greeting {
+  color: rgba(255, 255, 255, 0.9);
+  font-size: 14px;
+}
+
+/* ── Login modal ──────────────────────────────────────────────────────────── */
+
+.modal {
+  position: fixed;
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.modal-content {
+  background: white;
+  padding: 30px;
+  border-radius: 8px;
+  width: 100%;
+  max-width: 380px;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+}
+
+.modal-content h3 {
+  margin-bottom: 20px;
+  color: #1a237e;
+}
+
+.modal-actions {
+  display: flex;
+  gap: 10px;
+  margin-top: 10px;
+}
+
+.modal-actions button[type="button"] {
+  background-color: #757575;
+}
+
+.modal-actions button[type="button"]:hover {
+  background-color: #9e9e9e;
 }

--- a/src/teachers.json
+++ b/src/teachers.json
@@ -1,5 +1,4 @@
 {
-  "_comment": "Passwords are stored as pbkdf2:sha256:<salt>:<hash>. Use the /auth/hash-password endpoint to generate new entries.",
-  "ms.johnson": "pbkdf2:sha256:4d6572676e61746f6e48696768:8b7a3f2e1c9d0a5b4e8f2c6d1a9e3b7f4c8d0e2a6b5c9d3f7e1b4a8c2e6f0d3a",
-  "mr.smith": "pbkdf2:sha256:5363686f6f6c41646d696e3231:3a1b5c9d7e2f4a8b6c0d3e5f7a9b1c3d5e7f9a0b2c4d6e8f0a1b3c5d7e9f2a4b"
+  "ms.johnson": "plain:password123",
+  "mr.smith": "plain:teacher456"
 }

--- a/src/teachers.json
+++ b/src/teachers.json
@@ -1,0 +1,5 @@
+{
+  "_comment": "Passwords are stored as pbkdf2:sha256:<salt>:<hash>. Use the /auth/hash-password endpoint to generate new entries.",
+  "ms.johnson": "pbkdf2:sha256:4d6572676e61746f6e48696768:8b7a3f2e1c9d0a5b4e8f2c6d1a9e3b7f4c8d0e2a6b5c9d3f7e1b4a8c2e6f0d3a",
+  "mr.smith": "pbkdf2:sha256:5363686f6f6c41646d696e3231:3a1b5c9d7e2f4a8b6c0d3e5f7a9b1c3d5e7f9a0b2c4d6e8f0a1b3c5d7e9f2a4b"
+}


### PR DESCRIPTION
## Summary

Fixes #5 — Students were removing each other from activities to free up spots. This PR adds a teacher-only admin mode so that only authenticated teachers can sign up or unregister students.

## Changes

### `src/teachers.json` (new)
- Stores teacher credentials (username + PBKDF2-hashed password)
- Plain-text passwords are auto-upgraded to hashed on first successful login
- Initial credentials: `ms.johnson` / `password123`, `mr.smith` / `teacher456`

### `src/app.py`
- Added `POST /auth/login` — validates credentials and returns a session token
- Added `POST /auth/logout` — invalidates the session token
- `POST /activities/{name}/signup` and `DELETE /activities/{name}/unregister` now require a valid `Authorization: Bearer <token>` header (teachers only)
- Passwords hashed with PBKDF2-HMAC-SHA256 using per-user salts

### `src/static/index.html`
- Added **👤 Teacher Login** button in the top-right of the header
- Added login modal with username/password fields and error feedback
- Sign Up form is hidden unless a teacher is logged in

### `src/static/app.js`
- Login/logout flow using `sessionStorage` for token persistence
- All signup/unregister API calls include the `Authorization` header
- Delete (❌) buttons on participant lists only render when a teacher is logged in

### `src/static/styles.css`
- Styles for the header auth controls (positioned top-right)
- Styles for the login modal overlay and form
